### PR TITLE
added fix for south glos (not sure if this is local to my street)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SouthGloucestershireCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SouthGloucestershireCouncil.cs
@@ -44,7 +44,7 @@ namespace BinDays.Api.Collectors.Collectors.Councils
 			{
 				Name = "General Waste",
 				Colour = "Black",
-				Keys = new List<string>() { "R" }.AsReadOnly(),
+				Keys = new List<string>() { "C" }.AsReadOnly(),
 			},
 		}.AsReadOnly();
 


### PR DESCRIPTION
it seems south Glos have changes some of there collection times and when running my address through my bin collection days are now underr R and not C for the key in the api response but not sure if this is a local issue for my street