### PR TITLE
Added new `ClientSideOptions` to request/responses.

### DIFF
--- a/BinDays.Api.Collectors/Models/ClientSideOptions.cs
+++ b/BinDays.Api.Collectors/Models/ClientSideOptions.cs
@@ -1,0 +1,18 @@
+namespace BinDays.Api.Collectors.Models
+{
+    /// <summary>
+    /// Client side request/response options to preserve across request/response cycles.
+    /// </summary>
+    public sealed class ClientSideOptions
+    {
+        /// <summary>
+        /// Follow HTTP redirects (3XX)
+        /// </summary>
+        public bool FollowRedirects { get; init; } = true;
+
+        /// <summary>
+        /// Metadata (e.g. tokens, cookies, etc.)
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; init; } = [];
+    }
+}

--- a/BinDays.Api.Collectors/Models/ClientSideRequest.cs
+++ b/BinDays.Api.Collectors/Models/ClientSideRequest.cs
@@ -31,5 +31,10 @@ namespace BinDays.Api.Collectors.Models
 		/// Gets the body of the request.
 		/// </summary>
 		required public string Body { get; init; }
+
+		/// <summary>
+		/// Gets the options of the request.
+		/// </summary>
+		public ClientSideOptions Options { get; init; } = new();
 	}
 }

--- a/BinDays.Api.Collectors/Models/ClientSideResponse.cs
+++ b/BinDays.Api.Collectors/Models/ClientSideResponse.cs
@@ -33,6 +33,11 @@ namespace BinDays.Api.Collectors.Models
 		required public string ReasonPhrase { get; init; }
 
 		/// <summary>
+		/// Gets the options of the response.
+		/// </summary>
+		public ClientSideOptions Options { get; init; } = new();
+
+		/// <summary>
 		/// Gets a value indicating whether the request was successful.
 		/// </summary>
 		public bool IsSuccessStatusCode => StatusCode >= 200 && StatusCode <= 299;

--- a/BinDays.Api.IntegrationTests/Helpers/IntegrationTestClient.cs
+++ b/BinDays.Api.IntegrationTests/Helpers/IntegrationTestClient.cs
@@ -132,7 +132,8 @@ namespace BinDays.Api.IntegrationTests.Helpers
 				StatusCode = (int)httpResponse.StatusCode,
 				Headers = responseHeaders,
 				Content = responseContent,
-				ReasonPhrase = httpResponse.ReasonPhrase ?? string.Empty
+				ReasonPhrase = httpResponse.ReasonPhrase ?? string.Empty,
+				Options = request.Options,
 			};
 		}
 


### PR DESCRIPTION
Added new client side options for request/responses to enable transfer of metadata between requests, and configuration of following redirects.