### PR TITLE
fix: apply bank holiday date revisions for Buckinghamshire Council

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
@@ -121,7 +121,7 @@ internal sealed partial class BuckinghamshireCouncil : ITouchVisionCollectorBase
 	/// Regex for parsing bank holiday revision table rows on the council website.
 	/// Matches a pair of table cells: the normal collection date and the revised collection date.
 	/// </summary>
-	[GeneratedRegex(@"<td>\s*\w+ (?<originalDay>\d{1,2}) (?<originalMonth>\w+).*?</td>.*?<td>\s*\w+ (?<revisedDay>\d{1,2}) (?<revisedMonth>\w+)", RegexOptions.Singleline)]
+	[GeneratedRegex(@"<td[^>]*>\s*\w+ (?<originalDay>\d{1,2}) (?<originalMonth>\w+).*?</td>.*?<td[^>]*>\s*\w+ (?<revisedDay>\d{1,2}) (?<revisedMonth>\w+)", RegexOptions.Singleline)]
 	private static partial Regex RevisionTableRegex();
 
 	/// <inheritdoc/>

--- a/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
@@ -208,7 +208,7 @@ internal sealed partial class BuckinghamshireCouncil : ITouchVisionCollectorBase
 
 				binDays.Add(new BinDay
 				{
-					Date = DateOnly.ParseExact(revisedDateStr, "yyyy-MM-dd"),
+					Date = DateUtilities.ParseDateExact(revisedDateStr, "yyyy-MM-dd"),
 					Address = binDay.Address,
 					Bins = binDay.Bins,
 				});

--- a/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BuckinghamshireCouncil.cs
@@ -2,12 +2,15 @@ namespace BinDays.Api.Collectors.Collectors.Councils;
 
 using BinDays.Api.Collectors.Collectors.Vendors;
 using BinDays.Api.Collectors.Models;
+using BinDays.Api.Collectors.Utilities;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Collector implementation for Buckinghamshire Council.
 /// </summary>
-internal sealed class BuckinghamshireCouncil : ITouchVisionCollectorBase, ICollector
+internal sealed partial class BuckinghamshireCouncil : ITouchVisionCollectorBase, ICollector
 {
 	/// <inheritdoc/>
 	public string Name => "Buckinghamshire Council";
@@ -112,5 +115,139 @@ internal sealed class BuckinghamshireCouncil : ITouchVisionCollectorBase, IColle
 		// Aylesbury Vale (North) consistently uses 9-digit UPRNs.
 		// South areas (Chiltern, South Bucks, Wycombe) consistently use 11 or 12 digit UPRNs.
 		return address.Uid!.Length > 9 ? _southBinTypes : _northBinTypes;
+	}
+
+	/// <summary>
+	/// Regex for parsing bank holiday revision table rows on the council website.
+	/// Matches a pair of table cells: the normal collection date and the revised collection date.
+	/// </summary>
+	[GeneratedRegex(@"<td>\s*\w+ (?<originalDay>\d{1,2}) (?<originalMonth>\w+).*?</td>.*?<td>\s*\w+ (?<revisedDay>\d{1,2}) (?<revisedMonth>\w+)", RegexOptions.Singleline)]
+	private static partial Regex RevisionTableRegex();
+
+	/// <inheritdoc/>
+	GetBinDaysResponse ICollector.GetBinDays(Address address, ClientSideResponse? clientSideResponse)
+	{
+		// Step 1: Fetch the council website to check for bank holiday date revisions
+		if (clientSideResponse == null)
+		{
+			var clientSideRequest = new ClientSideRequest
+			{
+				RequestId = 1,
+				Url = "https://www.buckinghamshire.gov.uk/waste-and-recycling/bin-collections/find-out-when-its-your-bin-collection/",
+				Method = "GET",
+			};
+
+			var getBinDaysResponse = new GetBinDaysResponse
+			{
+				NextClientSideRequest = clientSideRequest
+			};
+
+			return getBinDaysResponse;
+		}
+		// Step 1 response: parse revision table, then issue the iTouch Vision request
+		else if (clientSideResponse.RequestId == 1)
+		{
+			var revisions = ParseRevisions(clientSideResponse.Content);
+			var revisionsJson = JsonSerializer.Serialize(revisions);
+
+			// Reuse the base class to build the iTouch Vision request, then re-issue it as request ID 2
+			var itouchRequest = base.GetBinDays(address, null).NextClientSideRequest!;
+
+			var clientSideRequest = new ClientSideRequest
+			{
+				RequestId = 2,
+				Url = itouchRequest.Url,
+				Method = itouchRequest.Method,
+				Headers = itouchRequest.Headers,
+				Options = new ClientSideOptions
+				{
+					Metadata = { { "revisions", revisionsJson } },
+				},
+			};
+
+			var getBinDaysResponse = new GetBinDaysResponse
+			{
+				NextClientSideRequest = clientSideRequest
+			};
+
+			return getBinDaysResponse;
+		}
+		// Step 2 response: process iTouch Vision bin days and apply bank holiday revisions
+		else if (clientSideResponse.RequestId == 2)
+		{
+			var revisions = JsonSerializer.Deserialize<Dictionary<string, string>>(
+				clientSideResponse.Options.Metadata["revisions"])!;
+
+			// Present the response to the base class as request ID 1 so it can decrypt and parse it
+			var virtualResponse = new ClientSideResponse
+			{
+				RequestId = 1,
+				StatusCode = clientSideResponse.StatusCode,
+				Headers = clientSideResponse.Headers,
+				Content = clientSideResponse.Content,
+				ReasonPhrase = clientSideResponse.ReasonPhrase,
+			};
+
+			var baseBinDaysResponse = base.GetBinDays(address, virtualResponse);
+
+			if (revisions.Count == 0)
+			{
+				return baseBinDaysResponse;
+			}
+
+			var binDays = new List<BinDay>();
+
+			// Iterate through each bin day, and apply any bank holiday date revisions
+			foreach (var binDay in baseBinDaysResponse.BinDays!)
+			{
+				if (!revisions.TryGetValue(binDay.Date.ToString("yyyy-MM-dd"), out var revisedDateStr))
+				{
+					binDays.Add(binDay);
+					continue;
+				}
+
+				binDays.Add(new BinDay
+				{
+					Date = DateOnly.ParseExact(revisedDateStr, "yyyy-MM-dd"),
+					Address = binDay.Address,
+					Bins = binDay.Bins,
+				});
+			}
+
+			var getBinDaysResponse = new GetBinDaysResponse
+			{
+				BinDays = ProcessingUtilities.ProcessBinDays(binDays),
+			};
+
+			return getBinDaysResponse;
+		}
+
+		throw new InvalidOperationException("Invalid client-side request.");
+	}
+
+	/// <summary>
+	/// Parses the bank holiday revision table from the council website HTML.
+	/// Returns a dictionary mapping original dates (yyyy-MM-dd) to revised dates (yyyy-MM-dd).
+	/// </summary>
+	private static Dictionary<string, string> ParseRevisions(string html)
+	{
+		var revisions = new Dictionary<string, string>();
+
+		// Iterate through each revision table row, and build the date revision mapping
+		foreach (Match match in RevisionTableRegex().Matches(html)!)
+		{
+			var originalDate = DateUtilities.ParseDateInferringYear(
+				$"{match.Groups["originalDay"].Value} {match.Groups["originalMonth"].Value}",
+				"d MMMM"
+			);
+			var revisedDate = DateUtilities.ParseDateInferringYear(
+				$"{match.Groups["revisedDay"].Value} {match.Groups["revisedMonth"].Value}",
+				"d MMMM"
+			);
+
+			revisions[$"{originalDate:yyyy-MM-dd}"] = $"{revisedDate:yyyy-MM-dd}";
+		}
+
+		return revisions;
 	}
 }


### PR DESCRIPTION
## Summary

- The iTouchVision portal returns pre-revision bin collection dates and displays a notice directing users to the council website for bank holiday changes (e.g. Easter)
- Adds a pre-step to fetch and parse the revision table from the council website, storing the original → revised date mapping in request metadata
- Applies the remapping after the iTouchVision response is processed, covering all four sub-areas (Aylesbury Vale, Wycombe, South Bucks, Chiltern)

## Test plan

- [ ] Run `BuckinghamshireCouncilTests` against all four postcodes (HP22 5XA, HP13 5AW, HP9 1BG, HP7 0NQ) and verify revised dates are returned during bank holiday periods
- [ ] Confirm `SomersetCouncilTests` still passes (only other iTouchVision collector, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)