### PR TITLE
Skip 'bot protection' issues in daily collector scheduler

### DIFF
--- a/.github/scripts/schedule-collector/find-eligible-issue.js
+++ b/.github/scripts/schedule-collector/find-eligible-issue.js
@@ -39,6 +39,14 @@ module.exports = async ({ github, context, core }) => {
   for (const issue of issues) {
     core.info(`Checking issue #${issue.number}: ${issue.title}`);
 
+    // Skip issues with "bot protection" label (council websites with bot detection that
+    // prevent automated HTTP requests from succeeding)
+    const hasBotProtection = issue.labels.some(label => label.name === 'bot protection');
+    if (hasBotProtection) {
+      core.info(`  - Skipping: has "bot protection" label`);
+      continue;
+    }
+
     // Check issue was created from the council request template and has required fields filled in
     const body = issue.body || '';
 

--- a/.github/scripts/schedule-collector/find-eligible-issue.js
+++ b/.github/scripts/schedule-collector/find-eligible-issue.js
@@ -41,7 +41,7 @@ module.exports = async ({ github, context, core }) => {
 
     // Skip issues with "bot protection" label (council websites with bot detection that
     // prevent automated HTTP requests from succeeding)
-    const hasBotProtection = issue.labels.some(label => label.name === 'bot protection');
+    const hasBotProtection = issue.labels.some(label => label.name.toLowerCase() === 'bot protection');
     if (hasBotProtection) {
       core.info(`  - Skipping: has "bot protection" label`);
       continue;


### PR DESCRIPTION
Skip issues labelled `bot protection` when the daily scheduled action selects a New Collector issue to implement. This prevents the automated action from wasting run time on council websites that use bot detection.

Related to #322.

Generated with [Claude Code](https://claude.ai/code)