### PR TITLE
fix: disable redirect following for Plymouth form URL to get correct session ID

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/PlymouthCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/PlymouthCouncil.cs
@@ -63,6 +63,12 @@ internal sealed partial class PlymouthCouncil : GovUkCollectorBase, ICollector
 				RequestId = 1,
 				Url = "https://plymouth-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b/AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875/definition.json&redirectlink=/en&cancelRedirectLink=/en&consentMessage=yes",
 				Method = "GET",
+				Options = new ClientSideOptions
+				{
+					// The form URL returns a 302 with the form HTML (including sid) in the response body.
+					// Following the redirect leads to the portal homepage with a different, invalid sid.
+					FollowRedirects = false,
+				},
 			};
 
 			var getAddressesResponse = new GetAddressesResponse
@@ -186,6 +192,10 @@ internal sealed partial class PlymouthCouncil : GovUkCollectorBase, ICollector
 				RequestId = 1,
 				Url = "https://plymouth-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b/AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875/definition.json&redirectlink=/en&cancelRedirectLink=/en&consentMessage=yes",
 				Method = "GET",
+				Options = new ClientSideOptions
+				{
+					FollowRedirects = false,
+				},
 			};
 
 			var getBinDaysResponse = new GetBinDaysResponse

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/PlymouthCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/PlymouthCouncilTests.cs
@@ -21,6 +21,7 @@ public class PlymouthCouncilTests
 	[Theory]
 	[InlineData("pl36ag")]
 	[InlineData("pl67aa")]
+	[InlineData("pl54qg")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
Fixes #336

The Plymouth AchieveService form URL returns an HTTP 302 redirect, but the 302 response body contains the actual form HTML with the correct `sid` token. With `FollowRedirects=true` (the default), the app follows the redirect to the portal homepage, which has a different invalid `sid` causing the address lookup to return no results.

Setting `FollowRedirects=false` ensures the correct `sid` from the 302 response body is used. Also adds PL5 4QG as an integration test case.

Generated with [Claude Code](https://claude.ai/code)