### PR TITLE
fix: skip null hso_nextcollection entries in SouthGloucestershireCouncil

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SouthGloucestershireCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SouthGloucestershireCouncil.cs
@@ -145,8 +145,13 @@ internal sealed partial class SouthGloucestershireCouncil : GovUkCollectorBase, 
 			var binDays = new List<BinDay>();
 			foreach (var rawBinDayCollection in rawBinDayCollections)
 			{
-				var serviceName = rawBinDayCollection!["hso_servicename"]!.GetValue<string>();
-				var nextCollection = rawBinDayCollection["hso_nextcollection"]!.GetValue<string>();
+				// Skip entries with no next collection date
+				var nextCollectionNode = rawBinDayCollection!["hso_nextcollection"];
+				if (nextCollectionNode == null)
+					continue;
+
+				var serviceName = rawBinDayCollection["hso_servicename"]!.GetValue<string>();
+				var nextCollection = nextCollectionNode.GetValue<string>();
 
 				// Find matching bin types based on the service name containing a key (case-insensitive)
 				var matchedBins = ProcessingUtilities.GetMatchingBins(_binTypes, serviceName);


### PR DESCRIPTION
Fixes #334

The bin days API returns entries where `hso_nextcollection` is null (e.g. when a collection has already occurred with no future date yet). Attempting to call `GetValue<string>()` on a null `JsonNode` threw a `NullReferenceException`. The website's JavaScript correctly skips these entries; the collector now does the same.

Generated with [Claude Code](https://claude.ai/code)