### PR TITLE
fix: Sheffield City Council - use correct pointType per address (issue #523)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SheffieldCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SheffieldCityCouncil.cs
@@ -99,14 +99,17 @@ internal sealed class SheffieldCityCouncil : GovUkCollectorBase, ICollector
 			var addresses = new List<Address>();
 			foreach (var rawAddress in rawAddresses)
 			{
-				var uid = rawAddress.GetProperty("id").GetString()!;
+				var id = rawAddress.GetProperty("id").GetString()!;
 				var property = rawAddress.GetProperty("name").GetString()!.Trim();
+				// Some addresses (e.g. converted properties) use a non-PointAddress type in getCollectionDays
+				var type = rawAddress.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : null;
 
 				var address = new Address
 				{
 					Property = property,
 					Postcode = postcode,
-					Uid = uid,
+					// Uid format: "id" or "id;pointType" for non-PointAddress records
+					Uid = !string.IsNullOrEmpty(type) && type != "PointAddress" ? $"{id};{type}" : id,
 				};
 
 				addresses.Add(address);
@@ -130,10 +133,15 @@ internal sealed class SheffieldCityCouncil : GovUkCollectorBase, ICollector
 		// Prepare client-side request for getting bin days
 		if (clientSideResponse == null)
 		{
+			// Uid format: "id" or "id;pointType" for non-PointAddress records
+			var uidParts = address.Uid!.Split(';', 2);
+			var pointId = uidParts[0];
+			var pointType = uidParts.Length == 2 ? uidParts[1] : "PointAddress";
+
 			var requestBody = $$"""
 			{
-				"pointId": "{{address.Uid}}",
-				"pointType": "PointAddress",
+				"pointId": "{{pointId}}",
+				"pointType": "{{pointType}}",
 				"councilId": "{{_councilId}}"
 			}
 			""";

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/SheffieldCityCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/SheffieldCityCouncilTests.cs
@@ -20,14 +20,15 @@ public class SheffieldCityCouncilTests
 
 	[Theory]
 	[InlineData("S2 2RE")]
-	[InlineData("S10 1QP")]
-	public async Task GetBinDaysTest(string postcode)
+	[InlineData("S10 1QP", 36)]
+	public async Task GetBinDaysTest(string postcode, int addressIndex = 0)
 	{
 		await TestSteps.EndToEnd(
 			_client,
 			postcode,
 			_govUkId,
-			_outputHelper
+			_outputHelper,
+			addressIndex
 		);
 	}
 }

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/SheffieldCityCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/SheffieldCityCouncilTests.cs
@@ -20,6 +20,7 @@ public class SheffieldCityCouncilTests
 
 	[Theory]
 	[InlineData("S2 2RE")]
+	[InlineData("S10 1QP")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
Fix for #523 - Sheffield City Council collections not returning for house 115 at S10 1QP.

The `getCollectionDays` request hardcoded "PointAddress" as the `pointType` for all addresses. Some Sheffield properties (e.g. converted houses, flats) are stored with a different point type in the waste services system.

The fix reads the `type` field from `getPropertySearch` results and encodes it in the UID as `id;pointType` when it differs from "PointAddress". `GetBinDays` then parses this to pass the correct `pointType` to `getCollectionDays`. Legacy UIDs without a type suffix default to "PointAddress" for full backward compatibility.

Generated with [Claude Code](https://claude.ai/code)