### PR TITLE
Apply bank holiday date revisions for South Oxfordshire and Vale of White Horse

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SouthOxfordshireDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SouthOxfordshireDistrictCouncil.cs
@@ -19,4 +19,7 @@ internal sealed class SouthOxfordshireDistrictCouncil : BinzoneCollectorBase, IC
 
 	/// <inheritdoc/>
 	protected override string CouncilCode => "S";
+
+	/// <inheritdoc/>
+	protected override string CalendarUrl => "https://www.southoxon.gov.uk/south-oxfordshire-district-council/recycling-rubbish-and-waste/when-is-your-collection-day/waste-collections-calendar/";
 }

--- a/BinDays.Api.Collectors/Collectors/Councils/ValeOfWhiteHorseDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/ValeOfWhiteHorseDistrictCouncil.cs
@@ -19,4 +19,7 @@ internal sealed class ValeOfWhiteHorseDistrictCouncil : BinzoneCollectorBase, IC
 
 	/// <inheritdoc/>
 	protected override string CouncilCode => "V";
+
+	/// <inheritdoc/>
+	protected override string CalendarUrl => "https://www.whitehorsedc.gov.uk/vale-of-white-horse-district-council/recycling-rubbish-and-waste/when-is-your-collection-day/waste-collections-calendar/";
 }

--- a/BinDays.Api.Collectors/Collectors/Vendors/BinzoneCollectorBase.cs
+++ b/BinDays.Api.Collectors/Collectors/Vendors/BinzoneCollectorBase.cs
@@ -6,16 +6,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Base collector implementation for councils using the South and Vale BinDays API.
 /// </summary>
-internal abstract class BinzoneCollectorBase : GovUkCollectorBase
+internal abstract partial class BinzoneCollectorBase : GovUkCollectorBase
 {
 	/// <summary>
 	/// The council code used by the BinDays API ("S" for South Oxfordshire or "V" for Vale).
 	/// </summary>
 	protected abstract string CouncilCode { get; }
+
+	/// <summary>
+	/// The URL of the council's waste collections calendar page, used to scrape bank holiday revision tables.
+	/// </summary>
+	protected abstract string CalendarUrl { get; }
 
 	/// <summary>
 	/// The list of bin types for this collector.
@@ -67,6 +73,13 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 	/// The base URL for the BinDays property API.
 	/// </summary>
 	private const string _propertyApiBaseUrl = "https://forms.southandvale.gov.uk/api/property";
+
+	/// <summary>
+	/// Regex for parsing bank holiday revision table rows on the council website.
+	/// Matches a pair of table cells: the normal collection date and the revised collection date.
+	/// </summary>
+	[GeneratedRegex(@"<td[^>]*>\s*\w+ (?<originalDay>\d{1,2}) (?<originalMonth>\w+).*?</td>.*?<td[^>]*>\s*\w+ (?<revisedDay>\d{1,2}) (?<revisedMonth>\w+)", RegexOptions.Singleline)]
+	private static partial Regex RevisionTableRegex();
 
 	/// <inheritdoc/>
 	public GetAddressesResponse GetAddresses(string postcode, ClientSideResponse? clientSideResponse)
@@ -139,73 +152,48 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 			return GetLegacyBinDays(address, clientSideResponse);
 		}
 
-		// Prepare client-side request for getting bin days
+		// Step 1: Fetch the calendar page to check for bank holiday date revisions
 		if (clientSideResponse == null)
 		{
-			var clientSideRequest = new ClientSideRequest
+			return new GetBinDaysResponse
 			{
-				RequestId = 1,
-				Url = $"{_propertyApiBaseUrl}/bins/{address.Uid}",
-				Method = "GET",
-			};
-
-			var getBinDaysResponse = new GetBinDaysResponse
-			{
-				NextClientSideRequest = clientSideRequest,
-			};
-
-			return getBinDaysResponse;
-		}
-		// Process bin days from response
-		else if (clientSideResponse.RequestId == 1)
-		{
-			using var jsonDocument = JsonDocument.Parse(clientSideResponse.Content);
-			var setData = jsonDocument.RootElement.GetProperty("setData");
-			var binDays = new List<BinDay>();
-
-			if (setData.GetProperty("site").GetString()! != CouncilCode)
-			{
-				throw new InvalidOperationException("Address does not belong to this council.");
-			}
-
-			// Iterate through each collection week
-			foreach (var week in setData.GetProperty("week").EnumerateArray())
-			{
-				// Iterate through each collection day, and create bin day objects
-				foreach (var day in week.GetProperty("day").EnumerateArray())
+				NextClientSideRequest = new ClientSideRequest
 				{
-					var collectionDate = day.GetProperty("collection_date").GetString()!;
-					var date = DateUtilities.ParseDateExact(collectionDate, "dd/MM/yyyy");
-
-					// Iterate through each bin entry for the collection day
-					foreach (var bin in day.GetProperty("bins").EnumerateArray())
-					{
-						var service = bin.GetProperty("bin_type").GetString()!;
-						var matchedBins = ProcessingUtilities.GetMatchingBins(_binTypes, service);
-
-						if (matchedBins.Count == 0)
-						{
-							continue;
-						}
-
-						var binDay = new BinDay
-						{
-							Date = date,
-							Address = address,
-							Bins = matchedBins,
-						};
-
-						binDays.Add(binDay);
-					}
-				}
-			}
-
-			var getBinDaysResponse = new GetBinDaysResponse
-			{
-				BinDays = ProcessingUtilities.ProcessBinDays(binDays),
+					RequestId = 1,
+					Url = CalendarUrl,
+					Method = "GET",
+				},
 			};
+		}
 
-			return getBinDaysResponse;
+		// Step 1 response: parse revision table, then issue the bin days request
+		if (clientSideResponse.RequestId == 1)
+		{
+			var revisions = ParseRevisions(clientSideResponse.Content);
+			var revisionsJson = JsonSerializer.Serialize(revisions);
+
+			return new GetBinDaysResponse
+			{
+				NextClientSideRequest = new ClientSideRequest
+				{
+					RequestId = 2,
+					Url = $"{_propertyApiBaseUrl}/bins/{address.Uid}",
+					Method = "GET",
+					Options = new ClientSideOptions
+					{
+						Metadata = { { "revisions", revisionsJson } },
+					},
+				},
+			};
+		}
+
+		// Step 2 response: parse bin days and apply bank holiday revisions
+		if (clientSideResponse.RequestId == 2)
+		{
+			var revisions = JsonSerializer.Deserialize<Dictionary<string, string>>(
+				clientSideResponse.Options.Metadata["revisions"])!;
+
+			return BuildBinDaysResponse(address, clientSideResponse.Content, revisions);
 		}
 
 		throw new InvalidOperationException("Invalid client-side request.");
@@ -217,6 +205,7 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 	/// </summary>
 	private GetBinDaysResponse GetLegacyBinDays(Address address, ClientSideResponse? clientSideResponse)
 	{
+		// Step 1: Fetch the calendar page to check for bank holiday date revisions
 		if (clientSideResponse == null)
 		{
 			return new GetBinDaysResponse
@@ -224,13 +213,35 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 				NextClientSideRequest = new ClientSideRequest
 				{
 					RequestId = 1,
-					Url = $"{_propertyApiBaseUrl}/postcode/{address.Postcode}",
+					Url = CalendarUrl,
 					Method = "GET",
 				},
 			};
 		}
 
+		// Step 1 response: parse revision table, then issue the postcode lookup
 		if (clientSideResponse.RequestId == 1)
+		{
+			var revisions = ParseRevisions(clientSideResponse.Content);
+			var revisionsJson = JsonSerializer.Serialize(revisions);
+
+			return new GetBinDaysResponse
+			{
+				NextClientSideRequest = new ClientSideRequest
+				{
+					RequestId = 2,
+					Url = $"{_propertyApiBaseUrl}/postcode/{address.Postcode}",
+					Method = "GET",
+					Options = new ClientSideOptions
+					{
+						Metadata = { { "revisions", revisionsJson } },
+					},
+				},
+			};
+		}
+
+		// Step 2 response: resolve UPRN from postcode lookup, then issue the bin days request
+		if (clientSideResponse.RequestId == 2)
 		{
 			var uid = address.Uid!;
 			var index = int.Parse(uid.AsSpan(uid.LastIndexOf(':') + 1));
@@ -247,60 +258,106 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 			{
 				NextClientSideRequest = new ClientSideRequest
 				{
-					RequestId = 2,
+					RequestId = 3,
 					Url = $"{_propertyApiBaseUrl}/bins/{uprn}",
 					Method = "GET",
+					Options = new ClientSideOptions
+					{
+						Metadata = { { "revisions", clientSideResponse.Options.Metadata["revisions"] } },
+					},
 				},
 			};
 		}
 
-		if (clientSideResponse.RequestId == 2)
+		// Step 3 response: parse bin days and apply bank holiday revisions
+		if (clientSideResponse.RequestId == 3)
 		{
-			using var jsonDocument = JsonDocument.Parse(clientSideResponse.Content);
-			var setData = jsonDocument.RootElement.GetProperty("setData");
-			var binDays = new List<BinDay>();
+			var revisions = JsonSerializer.Deserialize<Dictionary<string, string>>(
+				clientSideResponse.Options.Metadata["revisions"])!;
 
-			if (setData.GetProperty("site").GetString()! != CouncilCode)
-			{
-				throw new InvalidOperationException("Address does not belong to this council.");
-			}
-
-			// Iterate through each collection week
-			foreach (var week in setData.GetProperty("week").EnumerateArray())
-			{
-				// Iterate through each collection day, and create bin day objects
-				foreach (var day in week.GetProperty("day").EnumerateArray())
-				{
-					var collectionDate = day.GetProperty("collection_date").GetString()!;
-					var date = DateUtilities.ParseDateExact(collectionDate, "dd/MM/yyyy");
-
-					// Iterate through each bin entry for the collection day
-					foreach (var bin in day.GetProperty("bins").EnumerateArray())
-					{
-						var service = bin.GetProperty("bin_type").GetString()!;
-						var matchedBins = ProcessingUtilities.GetMatchingBins(_binTypes, service);
-
-						if (matchedBins.Count == 0)
-						{
-							continue;
-						}
-
-						binDays.Add(new BinDay
-						{
-							Date = date,
-							Address = address,
-							Bins = matchedBins,
-						});
-					}
-				}
-			}
-
-			return new GetBinDaysResponse
-			{
-				BinDays = ProcessingUtilities.ProcessBinDays(binDays),
-			};
+			return BuildBinDaysResponse(address, clientSideResponse.Content, revisions);
 		}
 
 		throw new InvalidOperationException("Invalid client-side request.");
+	}
+
+	/// <summary>
+	/// Parses bin days from the Binzone API JSON response and applies bank holiday date revisions.
+	/// </summary>
+	private GetBinDaysResponse BuildBinDaysResponse(Address address, string content, Dictionary<string, string> revisions)
+	{
+		using var jsonDocument = JsonDocument.Parse(content);
+		var setData = jsonDocument.RootElement.GetProperty("setData");
+		var binDays = new List<BinDay>();
+
+		if (setData.GetProperty("site").GetString()! != CouncilCode)
+		{
+			throw new InvalidOperationException("Address does not belong to this council.");
+		}
+
+		foreach (var week in setData.GetProperty("week").EnumerateArray())
+		{
+			foreach (var day in week.GetProperty("day").EnumerateArray())
+			{
+				var collectionDate = day.GetProperty("collection_date").GetString()!;
+				var date = DateUtilities.ParseDateExact(collectionDate, "dd/MM/yyyy");
+
+				// The Binzone API does not account for bank holidays — it always returns the
+				// original scheduled collection date. Revisions are sourced from the council's
+				// calendar page and applied here.
+				if (revisions.TryGetValue(date.ToString("yyyy-MM-dd"), out var revisedDateStr))
+				{
+					date = DateUtilities.ParseDateExact(revisedDateStr, "yyyy-MM-dd");
+				}
+
+				foreach (var bin in day.GetProperty("bins").EnumerateArray())
+				{
+					var service = bin.GetProperty("bin_type").GetString()!;
+					var matchedBins = ProcessingUtilities.GetMatchingBins(_binTypes, service);
+
+					if (matchedBins.Count == 0)
+					{
+						continue;
+					}
+
+					binDays.Add(new BinDay
+					{
+						Date = date,
+						Address = address,
+						Bins = matchedBins,
+					});
+				}
+			}
+		}
+
+		return new GetBinDaysResponse
+		{
+			BinDays = ProcessingUtilities.ProcessBinDays(binDays),
+		};
+	}
+
+	/// <summary>
+	/// Parses the bank holiday revision table from the council website HTML.
+	/// Returns a dictionary mapping original dates (yyyy-MM-dd) to revised dates (yyyy-MM-dd).
+	/// </summary>
+	private static Dictionary<string, string> ParseRevisions(string html)
+	{
+		var revisions = new Dictionary<string, string>();
+
+		foreach (Match match in RevisionTableRegex().Matches(html))
+		{
+			var originalDate = DateUtilities.ParseDateInferringYear(
+				$"{match.Groups["originalDay"].Value} {match.Groups["originalMonth"].Value}",
+				"d MMMM"
+			);
+			var revisedDate = DateUtilities.ParseDateInferringYear(
+				$"{match.Groups["revisedDay"].Value} {match.Groups["revisedMonth"].Value}",
+				"d MMMM"
+			);
+
+			revisions[$"{originalDate:yyyy-MM-dd}"] = $"{revisedDate:yyyy-MM-dd}";
+		}
+
+		return revisions;
 	}
 }


### PR DESCRIPTION
## Summary

- The Binzone API (`forms.southandvale.gov.uk`) always returns original scheduled collection dates with `CollectionStatus: "Status: Normal"`, regardless of bank holidays — it has no bank holiday awareness
- Both South Oxfordshire and Vale of White Horse publish bank holiday revision tables on their council calendar pages, but these were not being applied
- Confirmed with live API calls: e.g. with the Spring bank holiday on Monday 25 May 2026, a Tuesday-collection address returned `26/05/2026` when it should be `27/05/2026`

## Changes

- `BinzoneCollectorBase`: made `partial`, added abstract `CalendarUrl` property, and inserted the council's calendar page as the first step of the `GetBinDays` request cycle (matching the pattern already used by `BuckinghamshireCouncil`). Bank holiday revision tables are scraped, serialised into `ClientSideOptions.Metadata`, and applied to the parsed Binzone dates. Both the standard and legacy UID paths are handled.
- `SouthOxfordshireDistrictCouncil`: added `CalendarUrl`
- `ValeOfWhiteHorseDistrictCouncil`: added `CalendarUrl`

## Test plan

- [ ] Integration tests pass for `SouthOxfordshireDistrictCouncilTests` and `ValeOfWhiteHorseDistrictCouncilTests`
- [ ] Verify during a bank holiday week that collection dates are shifted correctly (validated manually with live API calls on 24 May 2026, the day before the Spring bank holiday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)