### PR TITLE
Fix SunderlandCityCouncil missing Brown Garden Waste bin day

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SunderlandCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SunderlandCityCouncil.cs
@@ -73,7 +73,7 @@ internal sealed partial class SunderlandCityCouncil : GovUkCollectorBase, IColle
 	/// <summary>
 	/// Regex for the bin days from the data elements.
 	/// </summary>
-	[GeneratedRegex(@"<h2[^>]*>(?<service>[^<]+)</h2>.*?class=""datelabel"">\s*(?<date>[^<]+)\s*</span>", RegexOptions.Singleline)]
+	[GeneratedRegex(@"<h2[^>]*>(?<service>[^<]+)</h2>.*?style=""display:inline-block;width:20px;""[^>]*></span>\s*<span[^>]*>\s*(?<date>[^<]+)\s*</span>", RegexOptions.Singleline)]
 	private static partial Regex BinDaysRegex();
 
 	/// <inheritdoc/>


### PR DESCRIPTION
## Summary

- The council website changed the Brown Garden Waste date span from `class="datelabel"` to an inline `style` attribute, while Green and Blue still use `class="datelabel"`
- Updated `BinDaysRegex` to anchor on the `style="display:inline-block;width:20px;"` spacer span that precedes all three date spans, instead of relying on `class="datelabel"`
- All 3 bin types now parse correctly: Green Waste, Mixed Recycling, and Garden Waste

## Test plan

- [x] Integration test passes locally: returns 2 bin days — 04/06 (General Waste + Garden Waste) and 11/06 (Mixed Recycling)
- [x] Build clean with 0 warnings

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)