### PR TITLE
Add IP14 4GX regression test for MidSuffolk

### DIFF
--- a/BinDays.Api.IntegrationTests/Collectors/Councils/MidSuffolkTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/MidSuffolkTests.cs
@@ -21,6 +21,7 @@ public class MidSuffolkTests
 	[Theory]
 	[InlineData("IP23 8LA")]
 	[InlineData("IP31 3FG")]
+	[InlineData("IP14 4GX")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
## Summary

- Investigated issue #570: Copperfield Way (IP14 4GX) bin days not showing in app
- Root cause confirmed as a **council data gap**, not a code bug — the addresses were recently added to the council's bin collection system when the new schedule launched on 1 June 2026
- Verified via Playwright: address 20 (UPRN `10095544665`) now has full collection data on the council website
- The collector code is correct: the regex matches the portlet HTML, date format `"dddd dd MMM yyyy"` handles "Wednesday 03 Jun 2026", and all bin type keys match
- Adding IP14 4GX as an integration test postcode to catch future regressions for this area

Closes #570

## Test plan

- [ ] Integration test passes for `IP14 4GX`
- [ ] Bin days returned for 20 Copperfield Way including Food Waste (weekly), Refuse, Recycling, Paper & Card on three-weekly Wednesday cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)