### PR TITLE
Fix Norwich City Council collector using expired session track as UID

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/NorwichCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/NorwichCityCouncil.cs
@@ -163,7 +163,7 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 	{
 		// TODO: Remove once legacy UIDs are no longer in circulation.
 		// Addresses cached before this fix use the old "{track};{pIndex}" format.
-		var pIndex = address.Uid!.Contains(';') ? address.Uid.Split(';', 2)[1] : address.Uid;
+		var pIndex = address.Uid!.Split(';')[^1];
 
 		// Prepare client-side request for getting the postcode form
 		if (clientSideResponse == null)

--- a/BinDays.Api.Collectors/Collectors/Councils/NorwichCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/NorwichCityCouncil.cs
@@ -58,15 +58,15 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 	private const string _baseUrl = "https://bnr-wrp.whitespacews.com";
 
 	/// <summary>
-	/// Regex for extracting the address lookup URL.
+	/// Regex for extracting the session track identifier.
 	/// </summary>
-	[GeneratedRegex(@"<form action=""(?<addressLookupUrl>https://bnr-wrp\.whitespacews\.com/mop\.php\?serviceID=A&Track=[^""]+&seq=2)""\s+method=""post""\s+oldTarget=""MoP""\s+align=""left""\s+data-form-title=""Property Lookup Form"">")]
-	private static partial Regex AddressLookupUrlRegex();
+	[GeneratedRegex(@"mop\.php\?serviceID=A&Track=(?<track>[^&""]+)&seq=2")]
+	private static partial Regex TrackRegex();
 
 	/// <summary>
 	/// Regex for extracting addresses from the address list.
 	/// </summary>
-	[GeneratedRegex(@"href=""mop\.php\?Track=(?<track>[^&""]+)&serviceID=A&seq=3&pIndex=(?<pIndex>\d+)""[^>]*>\s*(?<address>[^<]+)\s*</a>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+	[GeneratedRegex(@"href=""mop\.php\?Track=[^&""]+&serviceID=A&seq=3&pIndex=(?<pIndex>\d+)""[^>]*>\s*(?<address>[^<]+)\s*</a>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
 	private static partial Regex AddressRegex();
 
 	/// <summary>
@@ -98,7 +98,7 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 		// Prepare client-side request for address lookup
 		else if (clientSideResponse.RequestId == 1)
 		{
-			var addressLookupUrl = AddressLookupUrlRegex().Match(clientSideResponse.Content).Groups["addressLookupUrl"].Value;
+			var track = TrackRegex().Match(clientSideResponse.Content).Groups["track"].Value;
 
 			var requestBody = ProcessingUtilities.ConvertDictionaryToFormData(new()
 			{
@@ -108,7 +108,7 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 			var clientSideRequest = new ClientSideRequest
 			{
 				RequestId = 2,
-				Url = addressLookupUrl,
+				Url = $"{_baseUrl}/mop.php?serviceID=A&Track={track}&seq=2",
 				Method = "POST",
 				Headers = new()
 				{
@@ -134,15 +134,13 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 			var addresses = new List<Address>();
 			foreach (Match rawAddress in rawAddresses)
 			{
-				var track = rawAddress.Groups["track"].Value;
 				var pIndex = rawAddress.Groups["pIndex"].Value;
 
-				// Uid format: "track;pIndex"
 				var address = new Address
 				{
 					Property = rawAddress.Groups["address"].Value.Trim(),
 					Postcode = postcode,
-					Uid = $"{track};{pIndex}",
+					Uid = pIndex,
 				};
 
 				addresses.Add(address);
@@ -163,17 +161,72 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 	/// <inheritdoc/>
 	public GetBinDaysResponse GetBinDays(Address address, ClientSideResponse? clientSideResponse)
 	{
-		// Uid format: "track;pIndex"
-		var uidParts = address.Uid!.Split(';', 2);
-		var track = uidParts[0];
-		var pIndex = uidParts[1];
+		// TODO: Remove once legacy UIDs are no longer in circulation.
+		// Addresses cached before this fix use the old "{track};{pIndex}" format.
+		var pIndex = address.Uid!.Contains(';') ? address.Uid.Split(';', 2)[1] : address.Uid;
 
-		// Prepare client-side request for getting bin days
+		// Prepare client-side request for getting the postcode form
 		if (clientSideResponse == null)
 		{
 			var clientSideRequest = new ClientSideRequest
 			{
 				RequestId = 1,
+				Url = $"{_baseUrl}/?serviceID=A&seq=1",
+				Method = "GET",
+			};
+
+			var getBinDaysResponse = new GetBinDaysResponse
+			{
+				NextClientSideRequest = clientSideRequest,
+			};
+
+			return getBinDaysResponse;
+		}
+		// Prepare client-side request for address lookup
+		else if (clientSideResponse.RequestId == 1)
+		{
+			var track = TrackRegex().Match(clientSideResponse.Content).Groups["track"].Value;
+
+			var requestBody = ProcessingUtilities.ConvertDictionaryToFormData(new()
+			{
+				{ "address_postcode", address.Postcode! },
+			});
+
+			var clientSideRequest = new ClientSideRequest
+			{
+				RequestId = 2,
+				Url = $"{_baseUrl}/mop.php?serviceID=A&Track={track}&seq=2",
+				Method = "POST",
+				Headers = new()
+				{
+					{ "user-agent", Constants.UserAgent },
+					{ "content-type", Constants.FormUrlEncoded },
+				},
+				Body = requestBody,
+				Options = new ClientSideOptions
+				{
+					Metadata =
+					{
+						{ "track", track },
+					},
+				},
+			};
+
+			var getBinDaysResponse = new GetBinDaysResponse
+			{
+				NextClientSideRequest = clientSideRequest,
+			};
+
+			return getBinDaysResponse;
+		}
+		// Prepare client-side request for bin collection details
+		else if (clientSideResponse.RequestId == 2)
+		{
+			var track = clientSideResponse.Options.Metadata["track"];
+
+			var clientSideRequest = new ClientSideRequest
+			{
+				RequestId = 3,
 				Url = $"{_baseUrl}/mop.php?Track={track}&serviceID=A&seq=3&pIndex={pIndex}",
 				Method = "GET",
 			};
@@ -186,7 +239,7 @@ internal sealed partial class NorwichCityCouncil : GovUkCollectorBase, ICollecto
 			return getBinDaysResponse;
 		}
 		// Process bin days from response
-		else if (clientSideResponse.RequestId == 1)
+		else if (clientSideResponse.RequestId == 3)
 		{
 			var rawBinDays = BinDaysRegex().Matches(clientSideResponse.Content)!;
 

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/NorwichCityCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/NorwichCityCouncilTests.cs
@@ -29,4 +29,5 @@ public class NorwichCityCouncilTests
 			_outputHelper
 		);
 	}
+
 }


### PR DESCRIPTION
## Summary

- The Whitespace WS `Track` parameter is a time-stamped session token (e.g. `2026/06/02/RBHPJSIZPDROV`) that expires within days. The Norwich collector was storing it as part of the UID (`{track};{pIndex}`), causing all bin day lookups to fail once the token expired — matching the repeated `No bin days found` log entries.
- `GetBinDays` now follows the same 3-step pattern as `WaverleyBoroughCouncil`: fetch a fresh `Track` from the landing page, POST the address lookup to establish server-side session state, then fetch bin days using the fresh `Track` + `pIndex`.
- The UID is now just `pIndex` (e.g. `4`). Backwards-compatible: legacy UIDs in the old `{track};{pIndex}` format are detected by the presence of `;` and `pIndex` is extracted from the right-hand side, so existing cached addresses continue to work without requiring users to reselect.

## Test plan

- [x] Integration test against existing postcode (`NR3 3NE`) passes end-to-end
- [x] Manually validated both UIDs from the logs (`NR1 2NW / ...;4` and `NR3 3JU / ...;27`) return bin days correctly with the backwards-compat path

🤖 Generated with [Claude Code](https://claude.com/claude-code)