### PR TITLE
Fix Stratford-on-Avon District Council missing garden waste bin

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/StratfordOnAvonDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/StratfordOnAvonDistrictCouncil.cs
@@ -65,7 +65,7 @@ internal sealed partial class StratfordOnAvonDistrictCouncil : GovUkCollectorBas
 	/// <summary>
 	/// Regex for cells that contain a check mark, capturing their title.
 	/// </summary>
-	[GeneratedRegex(@"<td[^>]+title=""(?<title>[^""]+)""[^>]*>.*?check-img", RegexOptions.Singleline)]
+	[GeneratedRegex(@"<td[^>]+title=""(?<title>[^""]+)""[^>]*>(?:(?!</?td).)*?check-img", RegexOptions.Singleline)]
 	private static partial Regex CheckedCellRegex();
 
 	/// <inheritdoc/>

--- a/BinDays.Api.Collectors/Collectors/Councils/StratfordOnAvonDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/StratfordOnAvonDistrictCouncil.cs
@@ -59,11 +59,14 @@ internal sealed partial class StratfordOnAvonDistrictCouncil : GovUkCollectorBas
 	/// <summary>
 	/// Regex for the bin collection rows.
 	/// </summary>
-	[GeneratedRegex(
-		@"<tr>\s*<td>(?<date>[^<]+)</td>\s*<td[^>]*>(?<food>.*?)</td>\s*<td[^>]*>(?<recycling>.*?)</td>\s*<td[^>]*>(?<refuse>.*?)</td>",
-		RegexOptions.Singleline
-	)]
+	[GeneratedRegex(@"<tr>\s*<td>(?<date>[^<]+)</td>(?<cells>.*?)</tr>", RegexOptions.Singleline)]
 	private static partial Regex BinRowsRegex();
+
+	/// <summary>
+	/// Regex for cells that contain a check mark, capturing their title.
+	/// </summary>
+	[GeneratedRegex(@"<td[^>]+title=""(?<title>[^""]+)""[^>]*>.*?check-img", RegexOptions.Singleline)]
+	private static partial Regex CheckedCellRegex();
 
 	/// <inheritdoc/>
 	public GetAddressesResponse GetAddresses(string postcode, ClientSideResponse? clientSideResponse)
@@ -201,35 +204,19 @@ internal sealed partial class StratfordOnAvonDistrictCouncil : GovUkCollectorBas
 			var binDays = new List<BinDay>();
 			foreach (Match rawBinRow in rawBinRows)
 			{
-				var dateText = rawBinRow.Groups["date"].Value.Trim();
+				var date = DateUtilities.ParseDateExact(rawBinRow.Groups["date"].Value.Trim(), "dddd, dd/MM/yyyy");
 
-				var date = DateUtilities.ParseDateExact(dateText, "dddd, dd/MM/yyyy");
+				var bins = CheckedCellRegex()
+					.Matches(rawBinRow.Groups["cells"].Value)!
+					.SelectMany(m => ProcessingUtilities.GetMatchingBins(_binTypes, m.Groups["title"].Value))
+					.ToList();
 
-				var bins = new List<Bin>();
-
-				(string Group, string Key)[] binChecks =
-				[
-					("food", "Food waste"),
-					("recycling", "Recycling"),
-					("refuse", "Refuse"),
-				];
-
-				foreach (var binCheck in binChecks)
-				{
-					if (rawBinRow.Groups[binCheck.Group].Value.Contains("check-img", StringComparison.OrdinalIgnoreCase))
-					{
-						bins.AddRange(ProcessingUtilities.GetMatchingBins(_binTypes, binCheck.Key));
-					}
-				}
-
-				var binDay = new BinDay
+				binDays.Add(new BinDay
 				{
 					Date = date,
 					Address = address,
 					Bins = bins,
-				};
-
-				binDays.Add(binDay);
+				});
 			}
 
 			var getBinDaysResponse = new GetBinDaysResponse

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/StratfordOnAvonDistrictCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/StratfordOnAvonDistrictCouncilTests.cs
@@ -20,13 +20,15 @@ public class StratfordOnAvonDistrictCouncilTests
 
 	[Theory]
 	[InlineData("CV37 0TH")]
-	public async Task GetBinDaysTest(string postcode)
+	[InlineData("CV37 0TH", 32)]
+	public async Task GetBinDaysTest(string postcode, int addressIndex = 0)
 	{
 		await TestSteps.EndToEnd(
 			_client,
 			postcode,
 			_govUkId,
-			_outputHelper
+			_outputHelper,
+			addressIndex
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- Garden waste bin was never returned because the regex only captured 3 data columns (food, recycling, refuse), but the council's HTML table has a 4th column for garden waste when the address subscribes to that service
- Replaced the per-column named-group regex and `binChecks` mapping array with two `[GeneratedRegex]` patterns: one to match rows (capturing `date` + `cells`), and one to find checked cells by their `title` attribute — bin types are then resolved via the existing `GetMatchingBins` key lookup with no manual mapping needed
- Addresses without a garden waste subscription have only 3 data columns; the title-based approach handles both layouts naturally
- Added a second integration test case for address index 0 (no garden waste) alongside the existing index 32 (with garden waste)

## Test plan

- [x] `GetBinDaysTest("CV37 0TH", 0)` — address without garden waste service, 26 bin days returned
- [x] `GetBinDaysTest("CV37 0TH", 32)` — address with garden waste service, 26 bin days returned including garden waste
- [x] Both pass with `dotnet test --filter FullyQualifiedName~StratfordOnAvonDistrictCouncilTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)