### PR TITLE
Fix: Broken collector: NottinghamCityCouncil

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/NottinghamCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/NottinghamCityCouncil.cs
@@ -152,8 +152,8 @@ internal sealed class NottinghamCityCouncil : GovUkCollectorBase, ICollector
 		// Prepare client-side request for getting bin day events
 		if (clientSideResponse == null)
 		{
-			var after = DateTime.UtcNow.ToString("yyyy-MM-dd");
-			var before = DateTime.UtcNow.AddMonths(3).ToString("yyyy-MM-dd");
+			var after = DateTime.Today.ToString("yyyy-MM-dd");
+			var before = DateTime.Today.AddMonths(3).ToString("yyyy-MM-dd");
 
 			var clientSideRequest = new ClientSideRequest
 			{

--- a/BinDays.Api.Collectors/Collectors/Councils/NottinghamCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/NottinghamCityCouncil.cs
@@ -152,10 +152,13 @@ internal sealed class NottinghamCityCouncil : GovUkCollectorBase, ICollector
 		// Prepare client-side request for getting bin day events
 		if (clientSideResponse == null)
 		{
+			var after = DateTime.UtcNow.ToString("yyyy-MM-dd");
+			var before = DateTime.UtcNow.AddMonths(3).ToString("yyyy-MM-dd");
+
 			var clientSideRequest = new ClientSideRequest
 			{
 				RequestId = 1,
-				Url = $"{_apiBaseUrl}/api/places/{address.Uid!}/services/{_serviceId}/events?locale={_locale}",
+				Url = $"{_apiBaseUrl}/api/places/{address.Uid!}/services/{_serviceId}/events?after={after}&before={before}&locale={_locale}",
 				Method = "GET",
 			};
 

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/NottinghamCityCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/NottinghamCityCouncilTests.cs
@@ -20,6 +20,7 @@ public class NottinghamCityCouncilTests
 
 	[Theory]
 	[InlineData("NG3 5HJ")]
+	[InlineData("NG7 2NU")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/ValeOfWhiteHorseDistrictCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/ValeOfWhiteHorseDistrictCouncilTests.cs
@@ -21,6 +21,7 @@ public class ValeOfWhiteHorseDistrictCouncilTests
 	[Theory]
 	[InlineData("OX14 3AJ")]
 	[InlineData("OX14 4FQ")]
+	[InlineData("OX14 1JJ")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
## Summary

- The ReCollect events endpoint returns a fixed past-biased window when called without date parameters, causing no future collections to be returned for addresses in the NG7 2NU zone (and others in the same situation)
- Added `after` (today) and `before` (today + 3 months) query params to the events URL, matching how the council's own website calls the API
- Adds test coverage for two user-reported postcodes: `NG7 2NU` (Nottingham) and `OX14 1JJ` (Vale of White Horse)

## Test plan

- [x] `NottinghamCityCouncilTests` — NG3 5HJ (existing) and NG7 2NU (new) both pass with 21 and 13 future bin days respectively
- [x] `ValeOfWhiteHorseDistrictCouncilTests` — OX14 1JJ (new) passes with 2 future bin days; existing OX14 3AJ and OX14 4FQ unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)