### PR TITLE
Fix: Broken collector: SomersetCouncil (#608)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Vendors/ITouchVisionCollectorBase.cs
+++ b/BinDays.Api.Collectors/Collectors/Vendors/ITouchVisionCollectorBase.cs
@@ -155,11 +155,16 @@ internal abstract class ITouchVisionCollectorBase : GovUkCollectorBase
 				var binType = collectionItem.GetProperty("binType").GetString()!;
 				var matchedBins = ProcessingUtilities.GetMatchingBins(binTypes, binType);
 
-				var dateStrings = new[]
+				var dateStrings = new List<string?>
 				{
 					collectionItem.GetProperty("collectionDay").GetString(),
-					collectionItem.GetProperty("followingDay").GetString()
 				};
+
+				// The 'followingDay' field is optional and may be absent from the response.
+				if (collectionItem.TryGetProperty("followingDay", out var followingDay))
+				{
+					dateStrings.Add(followingDay.GetString());
+				}
 
 				foreach (var dateString in dateStrings)
 				{


### PR DESCRIPTION
## Summary

Fixes #608.

The `500 Internal Server Error` was misleading — it was **not** coming from the council's website (which works end-to-end). Tracing the request flow showed both iTouchVision calls actually return 200:

- `GetAddresses` (`kmbd/address`) → 200 ✓
- `GetBinDays` (`kmbd/collectionDay`) → 200 (verified via browser, plain HttpClient, and the curl-impersonate Dart client)

The 500 came from the **local API** when parsing the collectionDay response. The iTouchVision API changed its response shape — each collection item used to include a `followingDay` field, but now returns only `collectionDay`:

```json
{ "id": 48, "binType": "Rubbish Collection", "binColor": "#011a41", "description": "", "collectionDay": "03-07-2026" }
```

The collector called `collectionItem.GetProperty("followingDay").GetString()`, which threw `KeyNotFoundException`, so the API returned 500.

## Fix

In `ITouchVisionCollectorBase`, treat `followingDay` as optional via `TryGetProperty` instead of `GetProperty`. `collectionDay` remains required (fail-fast). The base class is shared with `BuckinghamshireCouncil`, so the change is safe whether or not the field is present.

## Testing

All 6 integration tests pass (Somerset + Buckinghamshire, addresses + bin days):

```
Passed!  - Failed: 0, Passed: 6, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)