### PR TITLE
Fix: Broken collector: WestSuffolkDistrictCouncil (#26)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/WestSuffolkDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/WestSuffolkDistrictCouncil.cs
@@ -63,7 +63,7 @@ internal sealed partial class WestSuffolkDistrictCouncil : GovUkCollectorBase, I
 	/// <summary>
 	/// Regex for the bin collection entries from the HTML response.
 	/// </summary>
-	[GeneratedRegex(@"<strong>(?<type>[^:]+):</strong>\s*(?<date>(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday) \d+(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December))", RegexOptions.Singleline)]
+	[GeneratedRegex(@"<strong>(?<type>[^:]+):</strong>\s*(?<date>(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s+\d+(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December))", RegexOptions.Singleline)]
 	private static partial Regex BinDaysRegex();
 
 	/// <summary>

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/WestSuffolkDistrictCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/WestSuffolkDistrictCouncilTests.cs
@@ -19,14 +19,19 @@ public class WestSuffolkDistrictCouncilTests
 	}
 
 	[Theory]
-	[InlineData("IP32 7LW")]
-	public async Task GetBinDaysTest(string postcode)
+	[InlineData("IP32 7LW", 0)]
+	// Address index 2 has no garden waste (Brown) subscription, which reflows the
+	// page text so the Green bin date wraps after the day-of-week. This previously
+	// broke the parsing regex (issue #26).
+	[InlineData("IP32 7LW", 2)]
+	public async Task GetBinDaysTest(string postcode, int addressIndex)
 	{
 		await TestSteps.EndToEnd(
 			_client,
 			postcode,
 			_govUkId,
-			_outputHelper
+			_outputHelper,
+			addressIndex
 		);
 	}
 }


### PR DESCRIPTION
## Problem

West Suffolk addresses **without a garden waste (Brown) subscription** were missing bins — notably the Green (Paper & Card) bin — even when the council page listed them. Reported in BadgerHobbs/BinDays-App#26.

## Root cause

When an address has no Brown entry, the council page reflows and the bin date can wrap right after the day-of-week, e.g.:

```
<strong>Green Bins:</strong> Tuesday⏎30th June
```

`BinDaysRegex` used a **literal space** between the day-name and day-number, so a newline there caused the whole entry to fail to match and the bin was silently dropped. (A previous fix only `\s+`-ified the gap before the month, so addresses that wrapped after the day-number worked while those wrapping after the day-name did not.)

## Fix

Make the day-name → day-number gap `\s+` so every gap inside the date tolerates a newline:

```
(?:…|Sunday)\s+\d+(?:st|nd|rd|th)?\s+(?:January|…)
```

## Testing

Integration test now parameterised over two addresses in `IP32 7LW`:
- index 0 — has a garden waste subscription (already worked)
- index 2 — no garden waste subscription (previously broken, now returns Food + Green for 30 June)

Both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)