### PR TITLE
Fix: Broken collector: BraintreeDistrictCouncil (#609)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/BraintreeDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BraintreeDistrictCouncil.cs
@@ -65,6 +65,7 @@ internal sealed partial class BraintreeDistrictCouncil : GovUkCollectorBase, ICo
 			[
 				"Food Recycling",
 				"Food Bin",
+				"Food Caddy",
 			],
 			Type = BinType.Caddy,
 		},
@@ -113,7 +114,7 @@ internal sealed partial class BraintreeDistrictCouncil : GovUkCollectorBase, ICo
 	/// <summary>
 	/// Regex for extracting bin services and dates from the date display blocks.
 	/// </summary>
-	[GeneratedRegex(@"<div class=""date_display""[^>]*>\s*<h3[^>]*>\s*(?<service>[^<]+)\s*</h3>\s*<p>\s*(?<date>\d{2}/\d{2}/\d{4})\s*</p>", RegexOptions.Singleline)]
+	[GeneratedRegex(@"<div class=""date_display""[^>]*>\s*(?:<img[^>]*>\s*)?<h3[^>]*>\s*(?<service>.*?)\s*</h3>\s*<p>\s*(?<date>\d{2}/\d{2}/\d{4})\s*</p>", RegexOptions.Singleline)]
 	private static partial Regex BinDaysRegex();
 
 	/// <inheritdoc/>


### PR DESCRIPTION
Fixes #609.

## Diagnosis
The reported `404` was not the council being "down" — the council request succeeds (HTTP 200). The 404 came from the BinDays API itself (`BinDaysNotFoundException`) because the collector parsed the results page and found **zero** bin days.

Braintree changed the results markup. Each collection block now looks like:

```html
<div class="date_display" style="border-color: #56504c;">
<img class="bin_image" src="...General_waste.png">
<h3 style="background-color:#56504c;">Non-recyclable waste<br>(grey bin)</h3>
<p>01/07/2026</p>
</div>
```

Two things broke `BinDaysRegex`:
1. A new `<img>` sits between the `date_display` div and the `<h3>`.
2. Service names now contain a `<br>`, which the `[^<]+` service group can't span.

Separately, the food service is now `Outdoor food caddy`, which didn't match the Food Waste keys (`Food Recycling`/`Food Bin`).

## Changes
- `BinDaysRegex`: allow an optional `<img>` and capture service names across `<br>` (`[^<]+` → `.*?`).
- Add a `"Food Caddy"` key to the Food Waste bin.

## Testing
`BraintreeDistrictCouncilTests` passes (was failing with 404). Verified the new regex against the live response markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)