### PR TITLE
Fix: Broken collector: BirminghamCityCouncil (#615)

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/BirminghamCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BirminghamCityCouncil.cs
@@ -60,7 +60,7 @@ internal sealed partial class BirminghamCityCouncil : GovUkCollectorBase, IColle
 	/// <summary>
 	/// Regex for the bin days from the data table elements.
 	/// </summary>
-	[GeneratedRegex(@"<tbody>\s*<tr>\s*<t.>(?<service>.*?)</t.>\s*<td>(?<date>.*?)</td>\s*</tr>\s*</tbody>")]
+	[GeneratedRegex(@"<tr>\s*<th>(?<service>[^<]+)</th>\s*<td>(?<date>[A-Za-z]{3} \d{2}/\d{2}/\d{4})</td>")]
 	private static partial Regex BinDaysRegex();
 
 	/// <inheritdoc/>


### PR DESCRIPTION
Fixes #615.

## Diagnosis
The reported `404` was not the council being "down" — the council request succeeds (HTTP 200, the "Collection schedules" page). The 404 came from the BinDays API itself (`BinDaysNotFoundException`) because the collector parsed the results and found **zero** bin days.

Birmingham changed the schedules table. Only one active row is returned, and the remaining rows are now an HTML comment carrying empty dates, sitting between the active `</tr>` and `</tbody>`:

```html
<tbody><tr><th>Household Collection</th><td>Mon 06/07/2026</td></tr><!--<tr><th>Food</th><td></td></tr><tr><th>Recycling</th><td></td></tr>--></tbody>
```

The old regex anchored on `</tr>` being immediately followed by `</tbody>`, so it matched nothing.

## Changes
- Replace `BinDaysRegex` with a per-row pattern that requires a real `Ddd dd/MM/yyyy` date. This matches the active row and naturally skips both the commented empty-date rows and the `<thead>`.

## Testing
`BirminghamCityCouncilTests` passes (was failing with 404). Verified the new regex against the live response markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)