### PR TITLE
Verify issue creation in test failure investigation workflow

### DIFF
--- a/.agent/prompts/investigate-test-failures.md
+++ b/.agent/prompts/investigate-test-failures.md
@@ -4,6 +4,8 @@ You are investigating integration test failures for the BinDays API project. Sch
 
 **IMPORTANT: This is a fully automated, non-interactive task running in a CI/CD pipeline.** There is NO user present to answer questions, provide clarification, or give approval. You cannot ask for help or confirmation - you must make all decisions autonomously and complete the entire task independently.
 
+**Completion criteria:** Your task is complete ONLY when `gh issue create` has succeeded for every failure where `needsInvestigation` is `true`. Do not end your turn after describing a plan — execute it fully. An automated check runs after you finish and fails the pipeline if any expected issue is missing.
+
 ## Input
 
 The file `failure-context.json` in the repository root contains:

--- a/.github/scripts/investigate-test-failures/investigate.sh
+++ b/.github/scripts/investigate-test-failures/investigate.sh
@@ -22,13 +22,21 @@ STYLE_GUIDE=$(cat .gemini/styleguide.md)
 PROMPT=$(cat .agent/prompts/investigate-test-failures.md)
 PROMPT="${PROMPT//\$STYLE_GUIDE/$STYLE_GUIDE}"
 
-# Councils that need investigation, from failure-context.json
-readarray -t COUNCILS < <(node -e "
+# Councils that need investigation, from failure-context.json.
+# Captured via command substitution (not process substitution) so a node
+# failure, e.g. missing or malformed JSON, is caught by set -e.
+COUNCILS_TEXT=$(node -e "
   const ctx = require('./failure-context.json');
   for (const f of ctx.failures) {
     if (f.needsInvestigation) console.log(f.councilName);
   }
 ")
+
+if [ -n "$COUNCILS_TEXT" ]; then
+  readarray -t COUNCILS <<< "$COUNCILS_TEXT"
+else
+  COUNCILS=()
+fi
 
 if [ ${#COUNCILS[@]} -eq 0 ]; then
   echo "No councils need investigation; nothing to do."

--- a/.github/scripts/investigate-test-failures/investigate.sh
+++ b/.github/scripts/investigate-test-failures/investigate.sh
@@ -4,10 +4,16 @@ set -e
 # Run Codex to investigate integration test failures.
 #
 # Reads the prompt template from .agent/prompts/investigate-test-failures.md,
-# substitutes the style guide, and invokes Codex CLI.
+# substitutes the style guide, and invokes Codex CLI. After each attempt,
+# verifies that an open "Broken collector: {council}" issue exists for every
+# council needing investigation, retrying Codex (scoped to the remaining
+# councils) if any are missing. Fails if issues are still missing after all
+# attempts, so a silent Codex no-op cannot pass the workflow.
 #
 # Required environment variables:
-#   (none — failure-context.json must exist in the repo root)
+#   GH_TOKEN — token for the gh CLI (failure-context.json must exist in the repo root)
+
+MAX_ATTEMPTS=3
 
 # Read the style guide for injection
 STYLE_GUIDE=$(cat .gemini/styleguide.md)
@@ -16,6 +22,60 @@ STYLE_GUIDE=$(cat .gemini/styleguide.md)
 PROMPT=$(cat .agent/prompts/investigate-test-failures.md)
 PROMPT="${PROMPT//\$STYLE_GUIDE/$STYLE_GUIDE}"
 
-# Run Codex with the prompt
-echo "Running Codex to investigate test failures..."
-codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "$PROMPT"
+# Councils that need investigation, from failure-context.json
+readarray -t COUNCILS < <(node -e "
+  const ctx = require('./failure-context.json');
+  for (const f of ctx.failures) {
+    if (f.needsInvestigation) console.log(f.councilName);
+  }
+")
+
+if [ ${#COUNCILS[@]} -eq 0 ]; then
+  echo "No councils need investigation; nothing to do."
+  exit 0
+fi
+
+# Populate MISSING_COUNCILS with councils that have no open tracking issue
+check_missing() {
+  local open_titles
+  open_titles=$(gh issue list --label collector-broken --state open --limit 100 --json title --jq '.[].title')
+
+  MISSING_COUNCILS=()
+  for council in "${COUNCILS[@]}"; do
+    if ! grep -qxF "Broken collector: ${council}" <<< "$open_titles"; then
+      MISSING_COUNCILS+=("$council")
+    fi
+  done
+}
+
+MISSING_COUNCILS=("${COUNCILS[@]}")
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  ATTEMPT_PROMPT="$PROMPT"
+
+  # On retries, scope the prompt to the councils still missing issues
+  if [ "$attempt" -gt 1 ]; then
+    ATTEMPT_PROMPT="$PROMPT
+
+## Retry Notice
+
+This is retry attempt ${attempt}. A previous attempt ended without creating all required issues.
+Only investigate and create issues for these councils: ${MISSING_COUNCILS[*]}.
+Do not create issues for any other council; they already have open issues."
+  fi
+
+  echo "Running Codex to investigate test failures (attempt ${attempt}/${MAX_ATTEMPTS})..."
+  codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "$ATTEMPT_PROMPT" || echo "Codex exited with an error; verifying issues anyway..."
+
+  check_missing
+
+  if [ ${#MISSING_COUNCILS[@]} -eq 0 ]; then
+    echo "All expected issues exist."
+    exit 0
+  fi
+
+  echo "Missing issues for: ${MISSING_COUNCILS[*]}"
+done
+
+echo "::error::Codex failed to create issues for: ${MISSING_COUNCILS[*]}"
+exit 1


### PR DESCRIPTION
## Problem

In today's scheduled run, the CheshireEastCouncil integration test failed (transient council website blip), but no GitHub issue was raised. The follow-up workflow ran Codex, which printed its plan, ran one command, and then ended its turn without investigating or creating any issue. Since `codex exec` exited 0, the job passed green — nothing verifies that issues were actually created.

Example: [Integration Test Follow-up run 29488858917](https://github.com/BadgerHobbs/BinDays-API/actions/runs/29488858917).

## Changes

**`investigate.sh`** — verify-and-retry instead of fire-and-forget:
- After each Codex run, checks via `gh issue list` that an open `Broken collector: {council}` issue exists for every council marked `needsInvestigation: true`
- Retries up to 3 attempts, with retry prompts scoped to only the still-missing councils (issue titles are the dedup key, so partial success can't create duplicates)
- A Codex crash no longer aborts the script; it verifies and retries anyway
- Exits 1 with an `::error::` annotation if issues are still missing after all attempts, so the job goes red instead of silently green

**`investigate-test-failures.md` prompt** — explicit completion criteria: not done until `gh issue create` has succeeded for every failure, don't end the turn after stating a plan, and an automated check will fail the pipeline otherwise.

## Testing

- `bash -n` syntax check passes
- Council extraction and missing-issue check logic smoke-tested against a fake `failure-context.json` (flags missing issue, clears once the issue title exists)
- Executable bit and LF line endings preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)