### PR TITLE
test: switch TelfordAndWrekinCouncil test to residential postcode TF4 3RD

### DIFF
--- a/BinDays.Api.IntegrationTests/Collectors/Councils/TelfordAndWrekinCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/TelfordAndWrekinCouncilTests.cs
@@ -19,7 +19,7 @@ public class TelfordAndWrekinCouncilTests
 	}
 
 	[Theory]
-	[InlineData("TF5 0LA")]
+	[InlineData("TF4 3RD")]
 	public async Task GetBinDaysTest(string postcode)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
Switch the integration test postcode from TF5 0LA (Hortonwood industrial estate area) to TF4 3RD (Dawley, residential). Residential addresses receive the full set of collections including garden waste, ensuring all 5 bin types are covered by the test.

Closes #639

Generated with [Claude Code](https://claude.ai/code)