### PR TITLE
Fix: South Norfolk Council missing food waste collections

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/SouthNorfolkCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SouthNorfolkCouncil.cs
@@ -49,14 +49,7 @@ internal sealed partial class SouthNorfolkCouncil : GovUkCollectorBase, ICollect
 		{
 			Name = "Food Waste",
 			Colour = BinColour.Grey,
-			Keys = [
-				"Food date",
-				"Fd date",
-				"Fod date",
-				"Food this",
-				"Fd this",
-				"Fod this"
-			],
+			Keys = [ "Foo date", "Foo this" ],
 			Type = BinType.Caddy,
 		},
 	];

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/SouthNorfolkCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/SouthNorfolkCouncilTests.cs
@@ -21,6 +21,7 @@ public class SouthNorfolkCouncilTests
 	[Theory]
 	[InlineData("NR18 0HQ")]
 	[InlineData("NR8 5GS", 16)]
+	[InlineData("IP21 4QU", 14)]
 	public async Task GetBinDaysTest(string postcode, int addressIndex = 0)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
## Summary
- Bug report: South Norfolk Council never returns Food Waste collection dates (address: 13 Norwich Road, Pulham St Mary, IP21 4QU).
- Root cause: the `Food Waste` bin's `Keys` guessed `"Food date"`, `"Fd date"`, `"Fod date"` (and `"...this"` variants), but the council's calendar SVG `<title>` text actually abbreviates it to **"Foo date"` / `"Foo this"`** (a 3-letter code, consistent with the existing `"Ref"`/`"Rec"` abbreviations for Refuse/Recycling). Confirmed directly against the live `WSCollExternal.asmx` SOAP response for the reported address via Playwright — none of the old keys ever appear, only `Foo date`/`Foo this` (66 occurrences in the fetched calendar).
- Fix: replace the guessed keys with the verified `"Foo date"`, `"Foo this"`.
- Added a regression test case for the reported address/postcode (`IP21 4QU`, addressIndex 14 → UPRN 2630135009) to `SouthNorfolkCouncilTests`.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test --filter FullyQualifiedName~SouthNorfolkCouncilTests` — all 3 cases pass, output now shows `Food Waste (Grey Caddy)` alongside General/Recycling on the correct Fridays for all three postcodes/addresses
- [x] `dotnet format --severity info` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)