### PR TITLE
Fix: Vale of White Horse / South Oxfordshire bag colour and type

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/ElmbridgeBoroughCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/ElmbridgeBoroughCouncil.cs
@@ -57,7 +57,7 @@ internal sealed partial class ElmbridgeBoroughCouncil : GovUkCollectorBase, ICol
 		new()
 		{
 			Name = "Clothes, Textiles and Small Electricals",
-			Colour = BinColour.Grey,
+			Colour = BinColour.Any,
 			Keys = [ "Textiles and Small WEEE" ],
 			Type = BinType.Bag,
 		},

--- a/BinDays.Api.Collectors/Collectors/Vendors/BinzoneCollectorBase.cs
+++ b/BinDays.Api.Collectors/Collectors/Vendors/BinzoneCollectorBase.cs
@@ -50,21 +50,21 @@ internal abstract class BinzoneCollectorBase : GovUkCollectorBase
 		new()
 		{
 			Name = "Small Electrical Items",
-			Colour = BinColour.Grey,
+			Colour = BinColour.Any,
 			Keys = [ "Small electricals" ],
-			Type = BinType.Sack,
+			Type = BinType.Bag,
 		},
 		new()
 		{
 			Name = "Textiles",
-			Colour = BinColour.Grey,
+			Colour = BinColour.Any,
 			Keys = [ "Textiles/Clothes" ],
-			Type = BinType.Sack,
+			Type = BinType.Bag,
 		},
 		new()
 		{
 			Name = "Batteries",
-			Colour = BinColour.Grey,
+			Colour = BinColour.Clear,
 			Keys = [ "Batteries" ],
 			Type = BinType.Bag,
 		},

--- a/BinDays.Api.Collectors/Models/BinColour.cs
+++ b/BinDays.Api.Collectors/Models/BinColour.cs
@@ -68,6 +68,19 @@ public sealed class BinColour
 	public static readonly BinColour Grey = new("Grey", "#9E9E9E");
 
 	/// <summary>
+	/// Clear (#9E9E9E). Same swatch as <see cref="Grey"/>, for items explicitly specified
+	/// as going out in a clear/transparent bag (e.g. batteries), rather than an unspecified colour.
+	/// </summary>
+	public static readonly BinColour Clear = new("Clear", "#9E9E9E");
+
+	/// <summary>
+	/// Any (#9E9E9E). Same swatch as <see cref="Grey"/>, for items with no official council
+	/// colour or receptacle (e.g. any bag left out alongside another bin). Combines with
+	/// <see cref="Bin.Type"/> in the app as "Any Bag"/"Any Sack".
+	/// </summary>
+	public static readonly BinColour Any = new("Any", "#9E9E9E");
+
+	/// <summary>
 	/// Yellow (#FFEB3B). Matches Flutter <c>Colors.yellow</c>.
 	/// </summary>
 	public static readonly BinColour Yellow = new("Yellow", "#FFEB3B");


### PR DESCRIPTION
## Summary
- A user reported (Vale of White Horse District Council) that the app showed "grey bags/sacks" for Textiles, Small Electrical Items, and Batteries, and asked where to buy them. `Grey` here was just an internal placeholder for "no official colour" — there is no such product.
- Added `BinColour.Any` (no colour specified, use any bag) and `BinColour.Clear` (council specifically asks for a clear/transparent bag) to `BinColour`, both rendering as the same neutral grey swatch but with names that read correctly in the app's `"{colour} {type}"` label (e.g. "Any Bag", "Clear Bag") instead of the ambiguous "Grey Sack".
- Applied `Clear` to Batteries (council confirms: clear bag), and `Any` to Textiles / Small Electrical Items (council confirms: any tied carrier bag) in `BinzoneCollectorBase` (Vale of White Horse & South Oxfordshire), and to Elmbridge's equivalent combined entry.
- Corrected Textiles and Small Electrical Items from `BinType.Sack` to `BinType.Bag` in `BinzoneCollectorBase`, matching the council's own wording ("tied carrier bag") rather than a sack.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — Vale of White Horse, South Oxfordshire, and Elmbridge integration tests pass against the live council APIs
- [x] Manually verified real bin day data for the reporter's address (19 Crown Fields, Harwell, Didcot, OX11 0FQ) renders as "Any Bag" / "Clear Bag" in the app's list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)