### PR TITLE
Fix: Broken collector: ArgyllAndButeCouncil

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/ArgyllAndButeCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/ArgyllAndButeCouncil.cs
@@ -72,7 +72,7 @@ internal sealed partial class ArgyllAndButeCouncil : GovUkCollectorBase, ICollec
 	/// <summary>
 	/// Regex for the addresses from the data.
 	/// </summary>
-	[GeneratedRegex(@"<option value=""(?<uid>[^""]*)"">(?<address>[^<]+)</option>")]
+	[GeneratedRegex(@"<option value=""(?<uid>[^""]*)""[^>]*>(?<address>[^<]+)</option>")]
 	private static partial Regex AddressRegex();
 
 	/// <summary>


### PR DESCRIPTION
Fixes #672

## Root cause

The CI failure captured in the issue (429 from gov.uk during `GetCollector`) turned out to be shared test-infra flakiness — 8 unrelated collectors failed identically in that same run, all at the gov.uk collector-resolution step, before any ArgyllAndButeCouncil-specific code ran.

The real, currently-reproducible bug (matching the issue's "Website changed" category) is in `GetAddresses`: the council's Drupal form now renders address `<option>` tags with a trailing space before the closing bracket:

```html
<option value="000125035048" >1 Lorn View, Achnacroish, Oban PA34 5UL</option>
```

`AddressRegex` required an exact `">"` with no space, so it matched zero addresses and the API returned 404 for every postcode. Verified live via Playwright against the real site (both by driving the form and by replaying the collector's raw POST request).

## What changed

- `AddressRegex` now allows arbitrary attributes/whitespace between the `value="..."` and the closing `>`.

## Validation

- Confirmed via Playwright that the site's bin-day table markup is unchanged (only the option tag format changed).
- `dotnet build` passes.
- `dotnet test --filter "FullyQualifiedName~ArgyllAndButeCouncilTests"` — all 12 postcodes pass against the live site.
- `dotnet format --severity info` — clean, no changes.

## Note on #679

There's an existing open PR (#679, auto-generated) for this issue that reduces request volume in `GetBinDays`. I checked it out and ran the same test suite against it — it still fails all 12 postcodes with the same 404, since it doesn't touch `GetAddresses`/`AddressRegex`. Recommend closing #679 in favor of this PR.