### PR TITLE
Fix four crashes found investigating today's error logs

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/BournemouthChristchurchAndPooleCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BournemouthChristchurchAndPooleCouncil.cs
@@ -21,6 +21,9 @@ internal sealed partial class BournemouthChristchurchAndPooleCouncil : GovUkColl
 	/// <inheritdoc/>
 	public override string GovUkId => "bournemouth-christchurch-poole";
 
+	/// <inheritdoc/>
+	public override int Version => 2;
+
 	/// <summary>
 	/// The list of bin types for this collector.
 	/// </summary>

--- a/BinDays.Api.Collectors/Collectors/Councils/EastSuffolkCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/EastSuffolkCouncil.cs
@@ -5,6 +5,7 @@ using BinDays.Api.Collectors.Models;
 using BinDays.Api.Collectors.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -134,12 +135,15 @@ internal sealed partial class EastSuffolkCouncil : GovUkCollectorBase, ICollecto
 				.GetProperty("transformed")
 				.GetProperty("rows_data");
 
+			// 'rows_data' is an empty array rather than an object when there are no results.
+			var addressEntries = rowsData.ValueKind == JsonValueKind.Object
+				? rowsData.EnumerateObject().Select(p => p.Value)
+				: rowsData.EnumerateArray();
+
 			// Iterate through each address, and create a new address object
 			var addresses = new List<Address>();
-			foreach (var row in rowsData.EnumerateObject())
+			foreach (var rowData in addressEntries)
 			{
-				var rowData = row.Value;
-
 				var address = new Address
 				{
 					Property = rowData.GetProperty("display").GetString()!.Trim(),
@@ -272,11 +276,15 @@ internal sealed partial class EastSuffolkCouncil : GovUkCollectorBase, ICollecto
 				.GetProperty("transformed")
 				.GetProperty("rows_data");
 
+			// 'rows_data' is an empty array rather than an object when there are no results.
+			var collectionEntries = rowsData.ValueKind == JsonValueKind.Object
+				? rowsData.EnumerateObject().Select(p => p.Value)
+				: rowsData.EnumerateArray();
+
 			// Iterate through each collection entry, and create a new bin day object
 			var binDays = new List<BinDay>();
-			foreach (var row in rowsData.EnumerateObject())
+			foreach (var rowData in collectionEntries)
 			{
-				var rowData = row.Value;
 				var service = rowData.GetProperty("CollectionType").GetString()!.Trim();
 				var collectionDate = rowData.GetProperty("CollectionDate").GetString()!.Trim();
 

--- a/BinDays.Api.Collectors/Collectors/Councils/SouthCambridgeshireDistrictCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/SouthCambridgeshireDistrictCouncil.cs
@@ -65,6 +65,12 @@ internal sealed partial class SouthCambridgeshireDistrictCouncil : GovUkCollecto
 	[GeneratedRegex(@"<th[^>]*scope=""row"">(?<date>[^<]+)", RegexOptions.Singleline)]
 	private static partial Regex BinDayDateRegex();
 
+	/// <summary>
+	/// Regex matching the plain-text response the site returns (400, not JSON) when a postcode has no premises.
+	/// </summary>
+	[GeneratedRegex(@"^No premises found for postcode:")]
+	private static partial Regex NoPremisesFoundRegex();
+
 	/// <inheritdoc/>
 	public GetAddressesResponse GetAddresses(string postcode, ClientSideResponse? clientSideResponse)
 	{
@@ -112,6 +118,16 @@ internal sealed partial class SouthCambridgeshireDistrictCouncil : GovUkCollecto
 		// Process addresses from response
 		else if (clientSideResponse.RequestId == 2)
 		{
+			// The site returns a plain-text "No premises found for postcode: ..." body (400, not JSON)
+			// when the postcode has no matches, e.g. it falls outside the council's area.
+			if (clientSideResponse.StatusCode == 400 && NoPremisesFoundRegex().IsMatch(clientSideResponse.Content))
+			{
+				return new GetAddressesResponse
+				{
+					Addresses = [],
+				};
+			}
+
 			using var jsonDoc = JsonDocument.Parse(clientSideResponse.Content);
 			var addressesHtml = jsonDoc.RootElement.GetProperty("addresses").GetString()!;
 

--- a/BinDays.Api.Collectors/Collectors/Vendors/ITouchVisionCollectorBase.cs
+++ b/BinDays.Api.Collectors/Collectors/Vendors/ITouchVisionCollectorBase.cs
@@ -145,39 +145,43 @@ internal abstract class ITouchVisionCollectorBase : GovUkCollectorBase
 			var decryptedJson = Decrypt(clientSideResponse.Content);
 			using var jsonDoc = JsonDocument.Parse(decryptedJson);
 
-			var collectionDayArray = jsonDoc.RootElement.GetProperty("collectionDay");
+			var collectionDayProperty = jsonDoc.RootElement.GetProperty("collectionDay");
 			var binDays = new List<BinDay>();
 
 			var binTypes = GetBinTypes(address);
 
-			foreach (var collectionItem in collectionDayArray.EnumerateArray())
+			// The 'collectionDay' field is 'null' rather than an empty array when a UPRN has no scheduled collections.
+			if (collectionDayProperty.ValueKind == JsonValueKind.Array)
 			{
-				var binType = collectionItem.GetProperty("binType").GetString()!;
-				var matchedBins = ProcessingUtilities.GetMatchingBins(binTypes, binType);
-
-				var dateStrings = new List<string?>
+				foreach (var collectionItem in collectionDayProperty.EnumerateArray())
 				{
-					collectionItem.GetProperty("collectionDay").GetString(),
-				};
+					var binType = collectionItem.GetProperty("binType").GetString()!;
+					var matchedBins = ProcessingUtilities.GetMatchingBins(binTypes, binType);
 
-				// The 'followingDay' field is optional and may be absent from the response.
-				if (collectionItem.TryGetProperty("followingDay", out var followingDay))
-				{
-					dateStrings.Add(followingDay.GetString());
-				}
-
-				foreach (var dateString in dateStrings)
-				{
-					if (!string.IsNullOrWhiteSpace(dateString))
+					var dateStrings = new List<string?>
 					{
-						var date = DateUtilities.ParseDateExact(dateString, "dd-MM-yyyy");
+						collectionItem.GetProperty("collectionDay").GetString(),
+					};
 
-						binDays.Add(new BinDay
+					// The 'followingDay' field is optional and may be absent from the response.
+					if (collectionItem.TryGetProperty("followingDay", out var followingDay))
+					{
+						dateStrings.Add(followingDay.GetString());
+					}
+
+					foreach (var dateString in dateStrings)
+					{
+						if (!string.IsNullOrWhiteSpace(dateString))
 						{
-							Date = date,
-							Address = address,
-							Bins = matchedBins
-						});
+							var date = DateUtilities.ParseDateExact(dateString, "dd-MM-yyyy");
+
+							binDays.Add(new BinDay
+							{
+								Date = date,
+								Address = address,
+								Bins = matchedBins
+							});
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Investigated 23 error-level log entries from 2026-07-29 by replaying the exact failing requests through the same libcurl-impersonate transport the app uses. Four councils had genuine, reproducible bugs (fixed here); two others (Northumberland, Waltham Forest — both `set-cookie` missing) turned out to be unreproducible transient upstream blips, not code issues, and are left alone.

## Changes and why

**`ITouchVisionCollectorBase.cs`** (Buckinghamshire, and shared by Newport/Somerset)
The iTouchVision API returns `"collectionDay": null` (not `[]`) for a UPRN with no scheduled collections. `.EnumerateArray()` on a JSON `null` throws `InvalidOperationException`. Now checks `ValueKind == JsonValueKind.Array` first and treats `null` as zero bin days.

**`EastSuffolkCouncil.cs`**
The apibroker `rows_data` field is an empty array (`[]`) instead of an object (`{}`) when there are no rows, crashing `.EnumerateObject()`. Reused the exact `ValueKind` check pattern already established in `LondonBoroughOfWalthamForest.cs` for the same upstream API quirk, applied to both places `rows_data` is enumerated (address search and bin day results).

**`SouthCambridgeshireDistrictCouncil.cs`**
Replaying the exact failing request (postcode `CB7 4AE`) showed the site returns **HTTP 400** with a plain-text body — `No premises found for postcode: CB74AE.` — instead of JSON, crashing `JsonDocument.Parse()`. Fixed by matching that specific status code + message before attempting to parse; any other unexpected failure (a real 500, etc.) still fails loudly rather than being silently swallowed. Side note: `CB7 4AE` is actually in East Cambridgeshire district, so this postcode was likely routed to the wrong collector to begin with — the site's "no premises found" response was correct.

**`BournemouthChristchurchAndPooleCouncil.cs`**
Traced to [`3ed313d`](https://github.com/BadgerHobbs/BinDays-API/commit/3ed313d593b6adcb001ca144b0d289234141c886), which migrated the address lookup to a new gazetteer API. That change altered the `Uid` format (from a raw UPRN to an internal search id that's resolved to a UPRN via an extra lookup step) but never bumped `Version`, even though `ICollector.Version`'s doc comment calls out exactly this case ("incremented when a breaking change is made, e.g. address UID format"). Any client still holding an address saved in the old format hits the detail-lookup endpoint with an id it no longer recognises, which 500s permanently (confirmed via direct replay — 3/3 requests failed identically, and the failing UID doesn't match the current id scheme at all for that postcode). Same failure class and fix as [Broxtowe (#661)](https://github.com/BadgerHobbs/BinDays-API/pull/661). Bumped `Version` to `2` so those clients get the existing 410 Gone / re-select-address flow instead of a crash.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet format --verify-no-changes --severity info` — no new issues in changed files
- [x] `dotnet test` against East Suffolk, Buckinghamshire, Newport, Somerset, South Cambridgeshire, and Bournemouth/Christchurch/Poole integration tests — all pass against the live council sites
- [x] Manually replayed each failing request via the real transport to confirm root cause before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)