### PR TITLE
Fix unsupported-collector metric always recording gov.uk ID as unknown

### DIFF
--- a/BinDays.Api/Controllers/CollectorsController.cs
+++ b/BinDays.Api/Controllers/CollectorsController.cs
@@ -182,7 +182,12 @@ public class CollectorsController : ControllerBase
 		catch (UnsupportedCollectorException ex)
 		{
 			_logger.LogWarning(ex, "Unsupported collector {CollectorName} for gov.uk ID: {GovUkId}, postcode: {Postcode}.", ex.CollectorName, ex.GovUkId, postcode);
-			_metrics.RecordLookup(Endpoints.Collector, SafeGovUkId(ex.GovUkId), Outcomes.UnsupportedCollector);
+
+			// Not run through SafeGovUkId: by definition an unsupported collector is never
+			// registered, so that gate would always collapse this to "unknown" and defeat the
+			// point of the label. ex.GovUkId is scraped from gov.uk's own site content rather
+			// than the unvalidated route parameter, so it's already bounded to real council ids.
+			_metrics.RecordLookup(Endpoints.Collector, ex.GovUkId, Outcomes.UnsupportedCollector);
 			return NotFound($"{ex.CollectorName} is not currently supported.");
 		}
 		catch (GovUkIdNotFoundException ex)


### PR DESCRIPTION
## Summary

Noticed while reviewing metrics: the `bindays.lookups` metric's `bindays.gov_uk_id` label always shows `unknown` for `Outcomes.UnsupportedCollector` events, even though the corresponding log line always has the real council and gov.uk ID (e.g. `Unsupported collector Durham County Council for gov.uk ID: county-durham, postcode: DH8 7HH.`).

Root cause: `SafeGovUkId` only lets a gov.uk ID through as a metric label if `CollectorService.IsRegistered(govUkId)` is true. But `UnsupportedCollectorException` is thrown *precisely because* no collector is registered for that ID — so the gate always fails and the label always collapses to `"unknown"`, for every single unsupported-collector event, defeating the purpose of the label entirely.

`SafeGovUkId`'s gating exists to bound cardinality against the `{govUkId}` route parameter, which is unvalidated user input. `UnsupportedCollectorException.GovUkId` isn't that — it comes from `GovUkCollectorBase.ExtractCollector`, scraped from gov.uk's own site content in response to a real postcode lookup, so it's already bounded to gov.uk's actual set of UK council identifiers (a few hundred, not attacker-controlled). Passing it through directly restores the per-council breakdown, which is exactly what you'd want to prioritize which collector to build next.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter UnsupportedCollectorTests` — passes
- [x] `dotnet format --verify-no-changes --severity info` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)