### PR TITLE
Fix Bristol collector dropping collections for communal-bin addresses

### DIFF
--- a/BinDays.Api.Collectors/Collectors/Councils/BristolCityCouncil.cs
+++ b/BinDays.Api.Collectors/Collectors/Councils/BristolCityCouncil.cs
@@ -41,21 +41,21 @@ internal sealed partial class BristolCityCouncil : GovUkCollectorBase, ICollecto
 		{
 			Name = "Cans & Plastics Recycling",
 			Colour = BinColour.Green,
-			Keys = [ "Green Recycling Box" ],
+			Keys = [ "Green Recycling Box", "Recycling Plastic/Cans" ],
 			Type = BinType.Box,
 		},
 		new()
 		{
 			Name = "Brown Paper & Cardboard Recycling",
 			Colour = BinColour.Blue,
-			Keys = [ "Blue Sack" ],
+			Keys = [ "Blue Sack", "Recycling Card", "Recycling Paper" ],
 			Type = BinType.Bag,
 		},
 		new()
 		{
 			Name = "Paper & Glass Recycling",
 			Colour = BinColour.Black,
-			Keys = [ "Black Recycling Box" ],
+			Keys = [ "Black Recycling Box", "Recycling Mixed Glass" ],
 			Type = BinType.Box,
 		},
 		new()
@@ -182,22 +182,28 @@ internal sealed partial class BristolCityCouncil : GovUkCollectorBase, ICollecto
 				var containerName = rawBinDayCollection!["containerName"]!.GetValue<string>();
 				var collectionArray = rawBinDayCollection["collection"]!.AsArray();
 
-				var collectionDate = collectionArray[0]!["nextCollectionDate"]!.GetValue<string>();
-
 				// Find matching bin types based on the container name containing a key (case-insensitive)
 				var matchedBins = ProcessingUtilities.GetMatchingBins(_binTypes, containerName);
 
-				// Parse the date string (e.g. "2025-04-15T00:00:00")
-				var date = DateUtilities.ParseDateExact(collectionDate, "yyyy-MM-dd'T'HH:mm:ss");
-
-				var binDay = new BinDay
+				// A container can have multiple active rounds (e.g. an every-other-week round A and
+				// round B), each with its own next collection date -- surface all of them rather than
+				// just the first, otherwise sooner dates from later rounds are silently missed.
+				foreach (var collection in collectionArray)
 				{
-					Date = date,
-					Address = address,
-					Bins = matchedBins,
-				};
+					var collectionDate = collection!["nextCollectionDate"]!.GetValue<string>();
 
-				binDays.Add(binDay);
+					// Parse the date string (e.g. "2025-04-15T00:00:00")
+					var date = DateUtilities.ParseDateExact(collectionDate, "yyyy-MM-dd'T'HH:mm:ss");
+
+					var binDay = new BinDay
+					{
+						Date = date,
+						Address = address,
+						Bins = matchedBins,
+					};
+
+					binDays.Add(binDay);
+				}
 			}
 
 			var getBinDaysResponse = new GetBinDaysResponse

--- a/BinDays.Api.IntegrationTests/Collectors/Councils/BristolCityCouncilTests.cs
+++ b/BinDays.Api.IntegrationTests/Collectors/Councils/BristolCityCouncilTests.cs
@@ -21,6 +21,7 @@ public class BristolCityCouncilTests
 	[Theory]
 	[InlineData("BS6 7SR")]
 	[InlineData("BS6 7SR", "000000355858", 1)]
+	[InlineData("BS2 0BA", "000000099849", 1)]
 	public async Task GetBinDaysTest(string postcode, string? pinnedUid = null, int? pinnedVersion = null)
 	{
 		await TestSteps.EndToEnd(


### PR DESCRIPTION
## Summary
- Communal/estate addresses (e.g. blocks of flats like Central Hall, Redcross Street) use container names such as `Recycling Card`, `Recycling Paper`, `Recycling Plastic/Cans`, and `Recycling Mixed Glass`, which weren't in the collector's bin type keys — only the kerbside box/sack naming was covered.
- Containers with multiple active collection rounds (e.g. alternating fortnightly A/B rounds that combine into a weekly collection) only had `collection[0]`'s date read, silently discarding the other round.
- Together these caused some collection days to match zero bin types and get dropped (`Bin day on {Date} ... matched no bin types and was dropped.` warnings seen in production logs for gov.uk ID `bristol`, postcode `BS2 0BA`).

## Investigation
Reproduced live against the real Bristol API for the affected address (UID `000000099849`, "20 Central Hall, Redcross Street, Bristol, BS2 0BA") and cross-checked the fixed output against Bristol's own public "Find your bin collection day" checker (waste.bristol.gov.uk) — the bin names and next-collection dates match exactly. The fix also correctly surfaces a second round's date for two containers (17 Aug General Waste, 20 Aug Food Waste) that the council's simplified single-row checker doesn't display, but which the same underlying API returns as genuine scheduled collections (round descriptions explicitly say "Every Other Week" per round, offset by a week from each other).

## Test plan
- [x] Added `BS2 0BA` / UID `000000099849` (communal-bin address) as a pinned test case in `BristolCityCouncilTests`
- [x] `dotnet build` succeeds
- [x] `dotnet test --filter FullyQualifiedName~BristolCityCouncilTests` — all 3 cases pass
- [x] `dotnet format --severity info --verify-no-changes` — clean, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)